### PR TITLE
Remove specific version tagging

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -7,6 +7,6 @@ runs:
       run: |
         VERSION=`node -pe "require('./package.json').version"`
         echo "[Github Action] Updated version: ${VERSION}"
-        yarn publish --non-interactive --tag ${VERSION}
+        yarn publish --non-interactive
         git push
       shell: bash


### PR DESCRIPTION
If you tag with a version number, it takes the place of the `latest` tag... which means that `yarn outdated` stops working