### PR TITLE
Feature/bhpl 768 add slack message when deploying

### DIFF
--- a/release-deploy/action.yml
+++ b/release-deploy/action.yml
@@ -7,6 +7,8 @@ inputs:
     required: true
   version:
     required: true
+  slack_webhook:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -41,5 +43,5 @@ runs:
           SLACK_TITLE: 'Deploying ${{ github.event.repository.name }} ${{ inputs.version }} to ${{ inputs.gyg_env }}_${{ inputs.gyg_region }}'
           SLACK_MESSAGE: 'Please check ${{ github.event.repository.name }} for new release version.'
           SLACK_USERNAME: Github
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
     

--- a/release-deploy/action.yml
+++ b/release-deploy/action.yml
@@ -12,6 +12,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Slack Notification
+      uses: rtcamp/action-slack-notify@v2
+      env:
+          SLACK_CHANNEL: gyg
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: 'Deploying ${{ github.event.repository.name }} ${{ inputs.version }} to ${{ inputs.gyg_env }}_${{ inputs.gyg_region }}'
+          SLACK_MESSAGE: 'Please check ${{ github.event.repository.name }} for a new release after a few minutes.'
+          SLACK_USERNAME: Github
+          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
     - run: |
         if ! [[ "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[\-0-9a-zA-z\.]*$ ]];
         then
@@ -35,13 +44,4 @@ runs:
         yarn release:diff || true
         yarn release:deploy
       shell: bash
-    - name: Slack Notification
-      uses: rtcamp/action-slack-notify@v2
-      env:
-          SLACK_CHANNEL: gyg
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_TITLE: 'Deploying ${{ github.event.repository.name }} ${{ inputs.version }} to ${{ inputs.gyg_env }}_${{ inputs.gyg_region }}'
-          SLACK_MESSAGE: 'Please check ${{ github.event.repository.name }} for new release version.'
-          SLACK_USERNAME: Github
-          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
     

--- a/release-deploy/action.yml
+++ b/release-deploy/action.yml
@@ -33,4 +33,13 @@ runs:
         yarn release:diff || true
         yarn release:deploy
       shell: bash
+    - name: Slack Notification
+      uses: rtcamp/action-slack-notify@v2
+      env:
+          SLACK_CHANNEL: gyg
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: 'Deploying ${{ github.event.repository.name }} ${{ inputs.version }} to ${{ inputs.gyg_env }}_${{ inputs.gyg_region }}'
+          SLACK_MESSAGE: 'Please check ${{ github.event.repository.name }} for new release version.'
+          SLACK_USERNAME: Github
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     

--- a/release-deploy/action.yml
+++ b/release-deploy/action.yml
@@ -12,15 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Slack Notification
-      uses: rtcamp/action-slack-notify@v2
-      env:
-          SLACK_CHANNEL: gyg
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_TITLE: 'Deploying ${{ github.event.repository.name }} ${{ inputs.version }} to ${{ inputs.gyg_env }}_${{ inputs.gyg_region }}'
-          SLACK_MESSAGE: 'Please check ${{ github.event.repository.name }} for a new release after a few minutes.'
-          SLACK_USERNAME: Github
-          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
     - run: |
         if ! [[ "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[\-0-9a-zA-z\.]*$ ]];
         then
@@ -44,4 +35,13 @@ runs:
         yarn release:diff || true
         yarn release:deploy
       shell: bash
+    - name: Slack Notification
+      uses: rtcamp/action-slack-notify@v2
+      env:
+          SLACK_CHANNEL: gyg
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: 'Deploying ${{ github.event.repository.name }} ${{ inputs.version }} to ${{ inputs.gyg_env }}_${{ inputs.gyg_region }}'
+          SLACK_MESSAGE: 'Deployment successful.'
+          SLACK_USERNAME: Github
+          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
     


### PR DESCRIPTION
Add Slack message when deploying
- Push message to **gyg** channel
- Because **SLACK_WEBHOOK** is available to private repositories, it should input the **slack_webhook** param from the private feature repo to Github action when running release-deploy action.

Note: If this PR is approved, all the feature repositories will add one more **slack_webhook** param at the Deploy release package in the deploy.yml file. (like guzmanygomez/bhyve-feature-example/pull/23)