### PR TITLE
BHPL-1155: add always auth to code artifact npm config

### DIFF
--- a/code-artifact/action.yml
+++ b/code-artifact/action.yml
@@ -4,5 +4,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        aws codeartifact login --tool npm --repository bhyve --domain gyg-internal-npm-repo
+        aws codeartifact login --tool npm --repository bhyve --domain gyg-internal-npm-repo 
+        echo "//gyg-internal-npm-repo-632572904405.d.codeartifact.ap-southeast-2.amazonaws.com/npm/bhyve/:always-auth=true" >> ~/.npmrc
+
       shell: bash


### PR DESCRIPTION
fixes code artifact unauthorized error in github actions with node 16 - otherwise if cache expires or is deleted all builds will fail