### PR TITLE
BHPL-2898: Forbid use of '_' in feature-branch names

### DIFF
--- a/release-tag/action.yml
+++ b/release-tag/action.yml
@@ -20,6 +20,13 @@ runs:
           exit 1;
         fi
       shell: bash
+    - name: Check branch name for underscores
+      run: |
+        if [[ "${{ inputs.branch }}" == *_* ]]; then
+          echo "::error::Branch name '${{ inputs.branch }}' contains '_'. Feature branches must use hyphens (-) instead of underscores."
+          exit 1
+        fi
+      shell: bash
     - id: modify-branch-name
       run: |
         echo "renaming branch '${{ inputs.branch }}' for version preid"


### PR DESCRIPTION
## Description
- feat(github): add ruleset to forbid underscores in feature branch names

## Jira ticket
https://guzman.atlassian.net/browse/BHPL-2898