### PR TITLE
feat(BHPL-3031): allow use of github PAT tokens

### DIFF
--- a/release-deploy-v2/action.yml
+++ b/release-deploy-v2/action.yml
@@ -34,7 +34,6 @@ runs:
         fi
       shell: bash
     - run: |
-        echo ${{ inputs.token }} | gh auth login --with-token
         zipName="*-${{ inputs.gyg_env }}-${{ inputs.gyg_region }}-${{ inputs.prefix_region }}-${{ inputs.version }}.zip"
         msg="Downloading artifact '$zipName' for deployment"
         echo $msg

--- a/release-deploy-v2/action.yml
+++ b/release-deploy-v2/action.yml
@@ -16,6 +16,10 @@ inputs:
     default: '.'
   prefix_region:
     required: true
+  token:
+    description: "GitHub token (PAT) used to authenticate gh operations"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "composite"
   steps:
@@ -30,12 +34,14 @@ runs:
         fi
       shell: bash
     - run: |
-        echo ${{ github.token }} | gh auth login --with-token
+        echo ${{ inputs.token }} | gh auth login --with-token
         zipName="*-${{ inputs.gyg_env }}-${{ inputs.gyg_region }}-${{ inputs.prefix_region }}-${{ inputs.version }}.zip"
         msg="Downloading artifact '$zipName' for deployment"
         echo $msg
         gh release download -p $zipName ${{ inputs.version }}
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       working-directory: ${{ inputs.working_directory }}
     - env:
         GYG_ENV: ${{ inputs.gyg_env }}

--- a/release-deploy/action.yml
+++ b/release-deploy/action.yml
@@ -24,6 +24,10 @@ inputs:
     default: '.'
   cdk_deploy_mode:
     required: false
+  token:
+    description: "GitHub token (PAT) used to authenticate gh operations"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "composite"
   steps:
@@ -37,12 +41,14 @@ runs:
         fi
       shell: bash
     - run: |
-        echo ${{ github.token }} | gh auth login --with-token
+        echo ${{ inputs.token }} | gh auth login --with-token
         zipName="*-${{ inputs.gyg_env }}-${{ inputs.gyg_region }}-${{ inputs.version }}.zip"
         msg="Downloading artifact '$zipName' for deployment"
         echo $msg
         gh release download -p $zipName ${{ inputs.version }}
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       working-directory: ${{ inputs.working_directory }}
     - env:
         GYG_PLATFORM: ${{ inputs.gyg_platform }}

--- a/release-deploy/action.yml
+++ b/release-deploy/action.yml
@@ -41,7 +41,6 @@ runs:
         fi
       shell: bash
     - run: |
-        echo ${{ inputs.token }} | gh auth login --with-token
         zipName="*-${{ inputs.gyg_env }}-${{ inputs.gyg_region }}-${{ inputs.version }}.zip"
         msg="Downloading artifact '$zipName' for deployment"
         echo $msg

--- a/release-package/action.yml
+++ b/release-package/action.yml
@@ -15,6 +15,10 @@ inputs:
   working_directory:
     required: false
     default: '.'
+  token:
+    description: "GitHub token (PAT) used to authenticate gh operations"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "composite"
   steps:
@@ -40,9 +44,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working_directory }}
     - run: |
-        echo ${{ github.token }} | gh auth login --with-token
+        echo ${{ inputs.token }} | gh auth login --with-token
         artifacts=*.zip; msg="Uploading $artifacts to release ${{ inputs.version }}"
         echo $msg
         gh release upload ${{ inputs.version }} *.zip
       shell: bash
       working-directory: ${{ inputs.working_directory }}
+      env:
+        GH_TOKEN: ${{ inputs.token }}

--- a/release-package/action.yml
+++ b/release-package/action.yml
@@ -44,7 +44,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working_directory }}
     - run: |
-        echo ${{ inputs.token }} | gh auth login --with-token
         artifacts=*.zip; msg="Uploading $artifacts to release ${{ inputs.version }}"
         echo $msg
         gh release upload ${{ inputs.version }} *.zip

--- a/release-tag/action.yml
+++ b/release-tag/action.yml
@@ -5,6 +5,10 @@ inputs:
     required: true
   branch:
     required: true
+  token:
+    description: "GitHub token (PAT) used to authenticate git and gh operations"
+    required: false
+    default: ${{ github.token }}
 outputs:
   version: # id of output
     description: "Version number output"
@@ -43,10 +47,13 @@ runs:
         fi
         VERSION=v`node -pe "require('./package.json').version"`
         echo "version=$(echo $VERSION)" >> $GITHUB_OUTPUT
+        echo ${{ inputs.token }} | gh auth login --with-token
+        gh auth setup-git
         git add .
         git commit -m "${{ inputs.version }} update - $VERSION" || true
         git push
         git push origin $VERSION
-        echo ${{ github.token }} | gh auth login --with-token
         gh release create $VERSION
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}

--- a/release-tag/action.yml
+++ b/release-tag/action.yml
@@ -47,7 +47,6 @@ runs:
         fi
         VERSION=v`node -pe "require('./package.json').version"`
         echo "version=$(echo $VERSION)" >> $GITHUB_OUTPUT
-        echo ${{ inputs.token }} | gh auth login --with-token
         gh auth setup-git
         git add .
         git commit -m "${{ inputs.version }} update - $VERSION" || true


### PR DESCRIPTION
Motivation
Unauthenticated GitHub API calls are limited to 60 requests per hour. By authenticating with the service account PAT, we increase the rate limit to 5,000 requests per hour, preventing pipeline failures caused by rate limiting.

This change will introduce:
- introduce new input to use a custom PAT token

